### PR TITLE
delete files from vendor

### DIFF
--- a/lib/line-count.coffee
+++ b/lib/line-count.coffee
@@ -129,6 +129,7 @@ module.exports =
           sfxMatch = /\.([^\.]+)$/.exec path
           if sfxMatch and
               (sfx = sfxMatch[1]) in suffixes and
+              path.indexOf('vendor') is -1 and
               path.indexOf('node_modules') is -1 and
               path.indexOf('bower_components') is -1 and
               (not @gitignore or @gitignore.accepts path)


### PR DESCRIPTION
In Go code we have a vendor folder that copy all dependencies of the project and make the stats not relevant. In my understanding this is like the node_modules dependencies.